### PR TITLE
Update city

### DIFF
--- a/templates/data/us/city
+++ b/templates/data/us/city
@@ -10,7 +10,6 @@ Columbus
 Dallas
 Denver
 Detroit
-Filadelfia
 Fort Worth
 Houston
 Indianapolis
@@ -28,6 +27,7 @@ New Orleans
 New York
 Oklahoma City
 Orlando
+Philadelphia
 Phoenix
 Pittsburgh
 Portland


### PR DESCRIPTION
Replace IT/ES spelling of "Filadelfia" with EN spelling "Philadelphia". Alphabetically sorted.