### PR TITLE
Correct embedded flag in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -91,7 +91,7 @@ If you want to use your own template, you can:
 For a quick and dirty test, the best option is to embed directly a template in the command:
 
 ```bash
-jr run --template "name:{{name}}"
+jr run --embedded "name:{{name}}"
 ```
 
 ### Create more random data 


### PR DESCRIPTION
I think the readme is out of data.  The correct flag to use for an embedded template is `--embedded` rather than `--template`