### PR TITLE
Added `inject` function

### DIFF
--- a/pkg/functions/functions.go
+++ b/pkg/functions/functions.go
@@ -24,11 +24,6 @@ import (
 	"bufio"
 	"encoding/csv"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/ugol/jr/pkg/constants"
-	"github.com/ugol/jr/pkg/ctx"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"log"
 	"math"
 	"math/rand"
@@ -37,6 +32,12 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+
+	"github.com/google/uuid"
+	"github.com/ugol/jr/pkg/constants"
+	"github.com/ugol/jr/pkg/ctx"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 func FunctionsMap() template.FuncMap {
@@ -46,6 +47,8 @@ func FunctionsMap() template.FuncMap {
 var Random = rand.New(rand.NewSource(0))
 var data = map[string][]string{}
 var fmap = map[string]interface{}{
+
+	"inject": Inject,
 
 	// text utilities
 	"atoi":                     Atoi,
@@ -522,4 +525,11 @@ func InitCSV(csvpath string) {
 		defer file.Close()
 	}
 
+}
+
+func Inject(perc float64, injected, orig string) string {
+	if rand.Float64() < perc {
+		return injected
+	}
+	return orig
 }


### PR DESCRIPTION
Fixes https://github.com/ugol/jr/issues/142

---

This PR adds an `inject` function that will override the original value if the percentage matches.

A `1` value means "always inject", while the `0` is "never".

A `0.5` will match with a probability of 50%.

```
-> % jr template run --embedded '{{city | inject 0.5 "<FAIL>" }}'
2024/07/16 22:55:49 JR configuration not found
<FAIL>

Elapsed time: 0s
Data Generated (Objects): 1
Data Generated (bytes): 6
Throughput (bytes per second):        49

-> % jr template run --embedded '{{city | inject 0.5 "<FAIL>" }}'
2024/07/16 22:55:51 JR configuration not found
Houston

Elapsed time: 0s
Data Generated (Objects): 1
Data Generated (bytes): 7
Throughput (bytes per second):        58
```