### PR TITLE
Fix #173 and #174

### DIFF
--- a/pkg/producers/gcs/gcsProducer.go
+++ b/pkg/producers/gcs/gcsProducer.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-
+        "strings"
 	"cloud.google.com/go/storage"
 	"github.com/google/uuid"
 

--- a/pkg/producers/gcs/gcsProducer.go
+++ b/pkg/producers/gcs/gcsProducer.go
@@ -52,10 +52,9 @@ func (p *GCSProducer) Produce(k []byte, v []byte, o any) {
 	bucket := p.bucket
 	var key string
 
-	if k == nil || len(k) == 0 {
+	if len(k) == 0 || strings.ToLower(string(k)) == "null" {
 		// generate a UUID as index
-		id := uuid.New()
-		key = id.String()
+		key = uuid.New().String()
 	} else {
 		key = string(k)
 	}

--- a/pkg/producers/gcs/gcsProducer.go
+++ b/pkg/producers/gcs/gcsProducer.go
@@ -55,9 +55,9 @@ func (p *GCSProducer) Produce(k []byte, v []byte, o any) {
 	if k == nil || len(k) == 0 {
 		// generate a UUID as index
 		id := uuid.New()
-		key = id.String() + "/.json"
+		key = id.String()
 	} else {
-		key = string(k) + "/.json"
+		key = string(k)
 	}
 
 	objectHandle := p.client.Bucket(bucket).Object(key)

--- a/pkg/producers/s3/s3Producer.go
+++ b/pkg/producers/s3/s3Producer.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
-
+        "strings"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"

--- a/pkg/producers/s3/s3Producer.go
+++ b/pkg/producers/s3/s3Producer.go
@@ -54,15 +54,15 @@ func (p *S3Producer) Produce(k []byte, v []byte, o any) {
 	if k == nil || len(k) == 0 {
 		// generate a UUID as index
 		id := uuid.New()
-		key = id.String() + "/.json"
+		key = id.String()
 	} else {
-		key = string(k) + "/.json"
+		key = string(k)
 	}
 
-	buffer := bytes.NewReader(v)
 
+        //object will be stored with no content type 
 	_, err := p.client.PutObject(&s3.PutObjectInput{
-		Body:   buffer,
+		Body:   bytes.NewReader(v),
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 	})

--- a/pkg/producers/s3/s3Producer.go
+++ b/pkg/producers/s3/s3Producer.go
@@ -51,10 +51,9 @@ func (p *S3Producer) Produce(k []byte, v []byte, o any) {
 	bucket := p.bucket
 	var key string
 
-	if k == nil || len(k) == 0 {
+	if len(k) == 0 || strings.ToLower(string(k)) == "null" {
 		// generate a UUID as index
-		id := uuid.New()
-		key = id.String()
+		key = uuid.New().String()
 	} else {
 		key = string(k)
 	}


### PR DESCRIPTION
s3 and gcs producers now use the same criteria used by azure storage producer to persist objects.

